### PR TITLE
feature/GIZFE-580 カテゴリー管理画面作成

### DIFF
--- a/src/components/pages/Articles/List.vue
+++ b/src/components/pages/Articles/List.vue
@@ -61,7 +61,6 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
-            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');
@@ -77,7 +76,6 @@ export default {
               this.$router.push({ path: '/notfound' });
             }
           }).catch(() => {
-            // console.log(err);
           });
       } else {
         this.$store.dispatch('articles/getAllArticles');

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -1,8 +1,3 @@
-<!-- YO:router-viewタグしかなかったので追記していきます。
-<template>
-  <router-view />
-</template> -->
-
 <template>
   <div class="categories">
     <app-category-post

--- a/src/components/pages/Categories/index.vue
+++ b/src/components/pages/Categories/index.vue
@@ -1,3 +1,75 @@
+<!-- YO:router-viewタグしかなかったので追記していきます。
 <template>
   <router-view />
+</template> -->
+
+<template>
+  <div class="categories">
+    <app-category-post
+      class="categories-item"
+      :error-message="errorMessage"
+      :access="access"
+    />
+    <app-category-list
+      class="categories-item"
+      :access="access"
+      :categories="categoryList"
+      :theads="theads"
+    />
+  </div>
 </template>
+
+<script>
+import { CategoryList, CategoryPost } from '@Components/molecules';
+
+export default {
+  components: {
+    appCategoryPost: CategoryPost,
+    appCategoryList: CategoryList,
+  },
+  data() {
+    return {
+      theads: ['カテゴリー名'],
+    };
+  },
+  computed: {
+    categoryList() {
+      return this.$store.state.categories.categoryList;
+    },
+    access() {
+      return this.$store.getters['auth/access'];
+    },
+    errorMessage() {
+      return this.$store.state.categories.errorMessage;
+    },
+    doneMessage() {
+      return this.$store.state.categories.doneMessage;
+    },
+  },
+  created() {
+    this.$store.dispatch('categories/getAllCategories');
+  },
+};
+</script>
+<style lang="scss" scoped>
+.categories {
+  display: flex;
+  flex-direction: row;
+
+  &-item:first-child {
+    width: 35%;
+    overflow: hidden;
+  }
+
+  &-item:last-child {
+    width: 65%;
+    overflow: hidden;
+
+  }
+  &-item + .categories-item{
+    border-left: 2px solid #e3e3e3;
+    margin-left: 20px;
+    padding-left: 20px;
+  }
+}
+</style>

--- a/src/js/_helpers/routeLinksArray.js
+++ b/src/js/_helpers/routeLinksArray.js
@@ -5,6 +5,11 @@ export default [
     path: '/',
   },
   {
+    id: 2,
+    name: 'カテゴリ',
+    path: '/categories',
+  },
+  {
     id: 3,
     name: '記事',
     path: '/articles',

--- a/src/js/_router/index.js
+++ b/src/js/_router/index.js
@@ -14,6 +14,9 @@ import ArticleDetail from '@Pages/Articles/Detail.vue';
 import ArticleEdit from '@Pages/Articles/Edit.vue';
 import ArticlePost from '@Pages/Articles/Post.vue';
 
+// ↓追加↓ カテゴリ
+import Categories from '@Pages/Categories/index.vue';
+
 // 自分のアカウントページ
 import Profile from '@Pages/Profile/index.vue';
 
@@ -106,6 +109,12 @@ const router = new VueRouter({
           component: ArticleEdit,
         },
       ],
+    },
+    // ↓追加↓ カテゴリ
+    {
+      name: 'categories',
+      path: '/categories',
+      component: Categories,
     },
     {
       path: '/users',

--- a/src/js/_store/index.js
+++ b/src/js/_store/index.js
@@ -3,6 +3,7 @@ import Vuex from 'vuex';
 import {
   auth, articles, users,
 } from './modules';
+import categories from './modules/categories';
 
 Vue.use(Vuex);
 export default new Vuex.Store({
@@ -11,5 +12,6 @@ export default new Vuex.Store({
     auth,
     articles,
     users,
+    categories,
   },
 });

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -1,0 +1,47 @@
+import axios from '@Helpers/axiosDefault';
+
+export default {
+  namespaced: true,
+  state: {
+    categoryList: [],
+    categories: [],
+    deleteCategoryId: null,
+    loading: false,
+    doneMessage: '',
+    errorMessage: '',
+  },
+  user: {
+    account_name: '',
+    created_at: '',
+    email: '',
+    full_name: '',
+    id: '',
+    password_reset_flg: null,
+    role: '',
+    updated_at: '',
+  },
+  mutations: {
+    doneGetAllCategories(state, categories) {
+      state.categoryList = categories.reverse();
+      state.loading = false;
+    },
+    failRequest(state, { message }) {
+      state.errorMessage = `${message}が発生しています。ご確認の上、再度お試しください。`;
+      state.loading = false;
+    },
+  },
+  actions: {
+    getAllCategories({ commit, rootGetters }) {
+      axios(rootGetters['auth/token'])({
+        method: 'GET',
+        url: '/category',
+      }).then(res => {
+        if (res.data.code === 0) throw new Error(res.data.message);
+        const categories = res.data.categories.map(data => data);
+        commit('doneGetAllCategories', categories);
+      }).catch(err => {
+        commit('failRequest', { message: err.message });
+      });
+    },
+  },
+};

--- a/src/js/_store/modules/categories.js
+++ b/src/js/_store/modules/categories.js
@@ -4,30 +4,16 @@ export default {
   namespaced: true,
   state: {
     categoryList: [],
-    categories: [],
     deleteCategoryId: null,
-    loading: false,
     doneMessage: '',
     errorMessage: '',
-  },
-  user: {
-    account_name: '',
-    created_at: '',
-    email: '',
-    full_name: '',
-    id: '',
-    password_reset_flg: null,
-    role: '',
-    updated_at: '',
   },
   mutations: {
     doneGetAllCategories(state, categories) {
       state.categoryList = categories.reverse();
-      state.loading = false;
     },
     failRequest(state, { message }) {
       state.errorMessage = `${message}が発生しています。ご確認の上、再度お試しください。`;
-      state.loading = false;
     },
   },
   actions: {


### PR DESCRIPTION
## チケットのリンク
https://gizumo.backlog.com/view/GIZFE-580

## やったこと
▼src/components/pages/Categories/index.vue
・moleculesのListとPostの内容をこちらのファイルにてまとめました。

▼src/js/_helpers/routeLinksArray.js
・サイドバーに「カテゴリー」の項目を表示させるために記述を追加しました。

▼src/js/_router/index.js
・ルーターに「カテゴリー」へのルートを追加しました。

▼src/js/_store/index.js
・Storeをまとめているファイルに「カテゴリー」のStoreも集約させました。

▼src/js/_store/modules/categories.js
・「カテゴリー」のStoreを記述しました。

## やらないこと
なし

## テスト
https://gizumo.backlog.com/view/GIZFE-582

## 特にレビューをお願いしたい箇所
・UserやArticleを参考にし、時にコードを拝借しながら作成しました。
　そのため、不要な記述が多いかもしれません。
　動きを見ながら関係なさそうな部分は削除しましたが、
　念のためご確認いただけますと幸いです。

・カテゴリー入力欄／カテゴリー一覧 の間にある区切り線をつけるのに苦戦し、
　結果的にボーダーを左側のみに付けると強硬手段を取りました。
　入力欄側の余白はmarginで、一覧側の余白はpaddingで付けており
　無理やり作った感じが否めないため、ご確認いただきたいです。
